### PR TITLE
Refactoring/urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/api/Endpoint.tsx
+++ b/src/api/Endpoint.tsx
@@ -1,4 +1,9 @@
-import { env } from "node:process";
+let url = "http://localhost:8125";
+
+const env = import.meta.env.MODE;
+if (env === 'production') {
+    url = "api.skillstorm-congo.com";
+}
 
 // Base URL for the backend API
-export const URL = env.BASE_API_ENDPOINT;
+export const URL = url;

--- a/src/api/Endpoint.tsx
+++ b/src/api/Endpoint.tsx
@@ -1,0 +1,4 @@
+import { env } from "node:process";
+
+// Base URL for the backend API
+export const URL = env.BASE_API_ENDPOINT;

--- a/src/api/Endpoint.tsx
+++ b/src/api/Endpoint.tsx
@@ -1,9 +1,4 @@
-let url = "http://localhost:8125";
-
-const env = import.meta.env.MODE;
-if (env === 'production') {
-    url = "api.skillstorm-congo.com";
-}
+let url = import.meta.env.VITE_BASE_API_ENDPOINT;
 
 // Base URL for the backend API
 export const URL = url;

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,6 @@
+This folder was made to centralize where endpoints are imported and used from
+so that URLs don't have to be changed across the project. 
+
+In order to update the URL, simply add the base endpoint path to an env variable called "BASE_API_ENDPOINT".
+
+In order to add a route, simply add to the service file it belongs to.

--- a/src/api/services/AccountService.tsx
+++ b/src/api/services/AccountService.tsx
@@ -3,7 +3,7 @@ import { URL } from "../Endpoint";
 const accountsUrl = URL + "/accounts";
 
 // Get accounts by user ID
-export const URL_getAccountsByUserId = accountsUrl + "/";
+export const URL_getAccountsByUserId = accountsUrl;
 
 // Get individual account by ID. Must replace {accountId} with the account ID.
 export const URL_getAccountByAccountIdAndUserId = accountsUrl + "/{accountId}";
@@ -12,7 +12,7 @@ export const getURL_getAccountByAccountIdAndUserId = (accountId: string) => {
 }
 
 // Create Account
-export const URL_createAccount = accountsUrl + "/";
+export const URL_createAccount = accountsUrl;
 
 // Update Account. Must replace {accountId} with the account ID.
 export const URL_updateAccount = accountsUrl + "/{accountId}";
@@ -27,4 +27,4 @@ export const getURL_deleteAccount = (accountId: string) => {
 }
 
 // Delete all accounts
-export const URL_deleteAllAccounts = accountsUrl + "/";
+export const URL_deleteAllAccounts = accountsUrl;

--- a/src/api/services/AccountService.tsx
+++ b/src/api/services/AccountService.tsx
@@ -1,0 +1,28 @@
+import { URL } from "../Endpoint";
+
+// Get accounts by user ID
+export const URL_getAccountsByUserId = URL + "/";
+
+// Get individual account by ID. Must replace {accountId} with the account ID.
+export const URL_getAccountByAccountIdAndUserId = URL + "/{accountId}";
+export const getURL_getAccountByAccountIdAndUserId = (accountId: string) => {
+    return URL_getAccountByAccountIdAndUserId.replace("{accountId}", accountId);
+}
+
+// Create Account
+export const URL_createAccount = URL + "/";
+
+// Update Account. Must replace {accountId} with the account ID.
+export const URL_updateAccount = URL + "/{accountId}";
+export const getURL_updateAccount = (accountId: string) => {
+    return URL_updateAccount.replace("{accountId}", accountId);
+}
+
+// Delete Account. Must replace {accountId} with the account ID.
+export const URL_deleteAccount = URL + "/{accountId}";
+export const getURL_deleteAccount = (accountId: string) => {
+    return URL_deleteAccount.replace("{accountId}", accountId);
+}
+
+// Delete all accounts
+export const URL_deleteAllAccounts = URL + "/";

--- a/src/api/services/AccountService.tsx
+++ b/src/api/services/AccountService.tsx
@@ -1,28 +1,30 @@
 import { URL } from "../Endpoint";
 
+const accountsUrl = URL + "/accounts";
+
 // Get accounts by user ID
-export const URL_getAccountsByUserId = URL + "/";
+export const URL_getAccountsByUserId = accountsUrl + "/";
 
 // Get individual account by ID. Must replace {accountId} with the account ID.
-export const URL_getAccountByAccountIdAndUserId = URL + "/{accountId}";
+export const URL_getAccountByAccountIdAndUserId = accountsUrl + "/{accountId}";
 export const getURL_getAccountByAccountIdAndUserId = (accountId: string) => {
     return URL_getAccountByAccountIdAndUserId.replace("{accountId}", accountId);
 }
 
 // Create Account
-export const URL_createAccount = URL + "/";
+export const URL_createAccount = accountsUrl + "/";
 
 // Update Account. Must replace {accountId} with the account ID.
-export const URL_updateAccount = URL + "/{accountId}";
+export const URL_updateAccount = accountsUrl + "/{accountId}";
 export const getURL_updateAccount = (accountId: string) => {
     return URL_updateAccount.replace("{accountId}", accountId);
 }
 
 // Delete Account. Must replace {accountId} with the account ID.
-export const URL_deleteAccount = URL + "/{accountId}";
+export const URL_deleteAccount = accountsUrl + "/{accountId}";
 export const getURL_deleteAccount = (accountId: string) => {
     return URL_deleteAccount.replace("{accountId}", accountId);
 }
 
 // Delete all accounts
-export const URL_deleteAllAccounts = URL + "/";
+export const URL_deleteAllAccounts = accountsUrl + "/";

--- a/src/api/services/AuthService.tsx
+++ b/src/api/services/AuthService.tsx
@@ -1,19 +1,21 @@
 import { URL } from "../Endpoint";
 
+const authUrl = URL + "/auth";
+
 // Registers a user
-export const URL_registerUser = URL + "/register";
+export const URL_registerUser = authUrl + "/register";
 
 // Login
-export const URL_loginUser = URL + "/login";
+export const URL_loginUser = authUrl + "/login";
 
 // Converts an oauth to a login
-export const URL_oauth2SocialLogin = URL + "/login/oauth2";
+export const URL_oauth2SocialLogin = authUrl + "/login/oauth2";
 
 // Logout
-export const URL_logout = URL + "/logout/redirect";
+export const URL_logout = authUrl + "/logout/redirect";
 
 // Update password
-export const URL_updatePassword = URL + "/update/password";
+export const URL_updatePassword = authUrl + "/update/password";
 
 // Validate token
-export const URL_validateJwt = URL + "/validate";
+export const URL_validateJwt = authUrl + "/validate";

--- a/src/api/services/AuthService.tsx
+++ b/src/api/services/AuthService.tsx
@@ -1,0 +1,19 @@
+import { URL } from "../Endpoint";
+
+// Registers a user
+export const URL_registerUser = URL + "/register";
+
+// Login
+export const URL_loginUser = URL + "/login";
+
+// Converts an oauth to a login
+export const URL_oauth2SocialLogin = URL + "/login/oauth2";
+
+// Logout
+export const URL_logout = URL + "/logout/redirect";
+
+// Update password
+export const URL_updatePassword = URL + "/update/password";
+
+// Validate token
+export const URL_validateJwt = URL + "/validate";

--- a/src/api/services/BudgetService.tsx
+++ b/src/api/services/BudgetService.tsx
@@ -1,0 +1,115 @@
+import { URL } from "../Endpoint";
+
+// --- BUCKETS CONTROLLER ---
+
+const bucketsUrl = URL + "/buckets";
+
+// Retrieves all bucket objects
+export const URL_getAllBuckets = bucketsUrl + "/all";
+
+// Retrieves all Bucket objects associated with a specific user ID
+export const URL_getAllBucketsByUserId = bucketsUrl + "/user";
+
+// Retrieves a specific Bucket object by its bucket ID
+export const URL_getBucketByBucketId = bucketsUrl + "/bucket/{bucketId}";
+export const getURL_getBucketByBucketId = (bucketId: string) => {
+    return URL_getBucketByBucketId.replace("{bucketId}", bucketId);
+}
+
+// Retrieves BUcket objects associated with a specific user ID and month-year
+export const URL_getBucketsByMonthYear = bucketsUrl + "/monthyear/{monthYear}";
+export const getURL_getBucketsByMonthYear = (monthYear: string) => {
+    return URL_getBudgetsByMonthYear.replace("{monthYear}", monthYear);
+}
+
+// Adds a new Bucket object.
+export const URL_addBucket = bucketsUrl + "/add";
+
+// Updates an existing Bucket object.
+export const URL_updateBucket = bucketsUrl + "/update/{bucketId}";
+export const getURL_updateBucket = (bucketId: string) => {
+    return URL_updateBucket.replace("{bucketId}", bucketId);
+}
+
+// Deletes a specific Bucket object by its bucket ID.
+export const URL_deleteBucket = bucketsUrl + "/delete/{bucketId}";
+export const getURL_deleteBucket = (bucketId: string) => {
+    return URL_deleteBucket.replace("{bucketId}", bucketId);
+}
+
+// Deletes all Bucket objects associated with a specific user ID.
+export const URL_deleteAllBucketsByUserId = bucketsUrl + "/deleteAll/user";
+
+// --- BUDGET CONTROLLER ---
+
+const budgetsUrl = URL + "/budgets";
+
+// Retrieves all the budgets from the budget repository
+export const URL_findAllBudgets = budgetsUrl;
+
+// Rerieves the Budget objects associated with the given ID.
+export const URL_getBudgetsById = budgetsUrl + "/userBudgets";
+
+// Creates a new budget by saving the provided Budget object.
+export const URL_createBudget = budgetsUrl;
+
+// Edits the details of a budget with the given ID.
+export const URL_editBudget = budgetsUrl + "/{id}";
+export const getURL_editBudget = (id: string) => {
+    return URL_editBudget.replace("{id}", id);
+}
+
+// Deletes a budget from the database by their ID.
+export const URL_deleteBudget = budgetsUrl + "/{id}";
+export const getURL_deleteBudget = (id: string) => {
+    return URL_deleteBudget.replace("{id}", id);
+}
+
+// Controller to receive the budgets a user has for a specific month and year
+export const URL_getBudgetsByMonthYear = budgetsUrl + "/monthyear/{monthYear}";
+export const getURL_getBudgetsByMonthYear = (monthYear: string) => {
+    return URL_getBudgetsByMonthYear.replace("{monthYear}", monthYear);
+}
+
+// Controller to receive the transactions a user had for a specific month year related to categories of budgets.
+export const URL_getTransactionsByMonthYear = budgetsUrl + "/transactions/{monthYear}";
+export const getURL_getTransactionsByMonthYear = (monthYear: string) => {
+    return URL_getTransactionsByMonthYear.replace("{monthYear}", monthYear);
+}
+
+// Controller to delete all budgets associated with a userId
+export const URL_deleteAllBudgetsByUserId = budgetsUrl + "/deleteAll/user";
+
+// --- MONTHLY SUMMARY CONTROLLER ---
+
+const monthlySummaryUrl = URL + "/summarys";
+
+// Retrieves all the monthly summaries from the monthly summary repository
+export const URL_findAllSummaries = monthlySummaryUrl;
+
+// Retrieves the summary objects associated with the given header user ID.
+export const URL_getSummaryById = monthlySummaryUrl + "/userSummarys";
+
+// Creates a new summary by saving the provided Summary object.
+export const URL_createMonthlySummary = monthlySummaryUrl;
+
+// Edits the details of a summary with the given ID.
+export const URL_editMonthlySummary = monthlySummaryUrl + "/{id}";
+export const getURL_editMonthlySummary = (id: string) => {
+    return URL_editMonthlySummary.replace("{id}", id);
+}
+
+// Deletes a summary from the database by their ID.
+export const URL_deleteSummary = monthlySummaryUrl + "/{id}";
+export const getURL_deleteSummary = (id: string) => {
+    return URL_deleteSummary.replace("{id}", id);
+}
+
+// Controller to receive the summaries a user has for a specific month and year
+export const URL_getSummariesByMonthYear = monthlySummaryUrl + "/monthyear/{monthYear}";
+export const getURL_getSummariesByMonthYear = (monthYear: string) => {
+    return URL_getSummariesByMonthYear.replace("{monthYear}", monthYear);
+}
+
+// Controller to delete all summaries associated with a userId
+export const URL_deleteAllSummariesByUserId = monthlySummaryUrl + "/deleteAll/user";

--- a/src/api/services/CreditScoreService.tsx
+++ b/src/api/services/CreditScoreService.tsx
@@ -1,0 +1,21 @@
+import { URL } from '../Endpoint';
+
+const creditScoreUrl = URL + '/api/credit';
+
+// Get credit score
+export const URL_getCreditScore = `${creditScoreUrl}/score`;
+
+// Save credit data
+export const URL_saveCreditData = `${creditScoreUrl}/data`;
+
+// Get credit score history
+export const URL_getCreditScoreHistory = `${creditScoreUrl}/history`;
+
+// Update user credit data
+export const URL_updateUserCreditData = `${creditScoreUrl}/data`;
+
+// Update credit accounts
+export const URL_getCreditReport = `${creditScoreUrl}/report`;
+
+// Get tips for credit improvement
+export const URL_getCreditImprovementTips = `${creditScoreUrl}/tips`;

--- a/src/api/services/TaxService.tsx
+++ b/src/api/services/TaxService.tsx
@@ -7,7 +7,7 @@ const deductionsUrl = URL + "/deductions";
 // Find deduction by deduction ID
 export const URL_findDeductionById = `${deductionsUrl}/{id}`;
 export const getUrl_findDeductionById = (id: number) => {
-    URL_findDeductionById.replace("{id}", id.toString());
+    return URL_findDeductionById.replace("{id}", id.toString());
 }
 
 // Retrieve list of all Deductions

--- a/src/api/services/TaxService.tsx
+++ b/src/api/services/TaxService.tsx
@@ -1,0 +1,181 @@
+import { URL } from '../Endpoint';
+
+// --- DEDUCTION CONTROLLER ---
+
+const deductionsUrl = URL + "/deductions";
+
+// Find deduction by deduction ID
+export const URL_findDeductionById = `${deductionsUrl}/{id}`;
+export const getUrl_findDeductionById = (id: number) => {
+    URL_findDeductionById.replace("{id}", id.toString());
+}
+
+// Retrieve list of all Deductions
+export const URL_findAllDeductions = deductionsUrl;
+
+// --- OTHER INCOME CONTROLLER ---
+
+const otherIncomeUrl = URL + "/other-income";
+
+// Find other income by tax return ID
+export const URL_findByTaxReturnId = `${otherIncomeUrl}/{taxReturnId}`;
+export const getUrl_findOtherIncomeByTaxReturnId = (taxReturnId: number) => {
+    return URL_findByTaxReturnId.replace("{taxReturnId}", taxReturnId.toString());
+}
+
+// Add other income
+export const URL_addOtherIncome = otherIncomeUrl;
+
+// Update other income
+export const URL_updateOtherIncome = otherIncomeUrl;
+
+// Delete other income by DTO
+export const URL_deleteOtherIncome = otherIncomeUrl;
+
+// Delete other income by ID
+export const URL_deleteOtherIncomeById = `${otherIncomeUrl}/{otherIncomeId}`;
+export const getUrl_deleteOtherIncomeById = (otherIncomeId: number) => {
+    return URL_deleteOtherIncomeById.replace("{otherIncomeId}", otherIncomeId.toString());
+}
+
+// --- TAX RETURN CONTROLLER ---
+
+const taxReturnsUrl = URL + "/taxreturns";
+
+// Add new TaxReturn. Should at least contain the year and can be updated later. Can also contain all user info but a
+// POST must be done before filing W2s because the TaxReturn ID is needed to associate the W2s with the TaxReturn:
+export const URL_addTaxReturn = taxReturnsUrl;
+
+// Get TaxReturn by id
+export const URL_findById = `${taxReturnsUrl}/{id}`;
+export const getUrl_findById = (id: number) => {
+    return URL_findById.replace("{id}", id.toString());
+}
+
+// Get current federal tax refund
+export const URL_getRefund = `${taxReturnsUrl}/{id}/refund`;
+export const getUrl_getRefund = (id: number) => {
+    return URL_getRefund.replace("{id}", id.toString());
+}
+
+// Get all TaxReturns by userId (and optionally by year)
+export const URL_findAllByUserId = taxReturnsUrl;
+
+// Update TaxReturn
+export const URL_updateTaxReturn = `${taxReturnsUrl}/{id}`;
+export const getUrl_updateTaxReturn = (id: number) => {
+    return URL_updateTaxReturn.replace("{id}", id.toString());
+}
+
+// Delete TaxReturn
+export const URL_deleteTaxReturn = `${taxReturnsUrl}/{id}`;
+export const getUrl_deleteTaxReturn = (id: number) => {
+    return URL_deleteTaxReturn.replace("{id}", id.toString());
+}
+
+// Claim deductions
+export const URL_claimDeduction = `${taxReturnsUrl}/{id}/deductions`;
+export const getUrl_claimDeduction = (id: number) => {
+    return URL_claimDeduction.replace("{id}", id.toString());
+}
+
+// View a TaxReturnDeduction by ID
+export const URL_getTaxReturnDeductionById = `${taxReturnsUrl}taxreturn/deductions/{taxReturnDeductionId}`;
+export const getUrl_getTaxReturnDeductionById = (taxReturnDeductionId: number) => {
+    return URL_getTaxReturnDeductionById.replace("{taxReturnDeductionId}", taxReturnDeductionId.toString());
+}
+
+// Get all deductions for a TaxReturn
+export const URL_getDeductions = `${taxReturnsUrl}/{id}/deductions`;
+export const getUrl_getDeductions = (id: number) => {
+    return URL_getDeductions.replace("{id}", id.toString());
+}
+
+// Update a TaxReturnDeduction
+export const URL_updateTaxReturnDeduction = `${taxReturnsUrl}taxreturn/deductions/{taxReturnDeductionId}`;
+export const getUrl_updateTaxReturnDeduction = (taxReturnDeductionId: number) => {
+    return URL_updateTaxReturnDeduction.replace("{taxReturnDeductionId}", taxReturnDeductionId.toString());
+}
+
+// Delete a TaxReturnDeduction
+export const URL_deleteTaxReturnDeduction = `${taxReturnsUrl}taxreturn/deductions/{taxReturnDeductionId}`;
+export const getUrl_deleteTaxReturnDeduction = (taxReturnDeductionId: number) => {
+    return URL_deleteTaxReturnDeduction.replace("{taxReturnDeductionId}", taxReturnDeductionId.toString());
+}
+
+// Delete absolutely everything associated with a UserId
+export const URL_deleteAllByUserId = `${taxReturnsUrl}/deleteAll`;
+
+// View all possible Filing Statuses
+export const URL_getFilingStatuses = `${taxReturnsUrl}/filingStatuses`;
+
+// Submit completed TaxReturn
+export const URL_submitTaxReturn = `${taxReturnsUrl}/{id}/submit`;
+export const getUrl_submitTaxReturn = (id: number) => {
+    return URL_submitTaxReturn.replace("{id}", id.toString());
+}
+
+// --- TAX RETURN CREDIT CONTROLLER ---
+
+const taxReturnCreditUrl = URL + "/tax-return-credit";
+
+// Find TaxReturnCredit by tax return ID
+export const URL_findTaxReturnCreditByTaxReturnId = `${taxReturnCreditUrl}/{taxReturnId}`;
+export const getUrl_findTaxReturnCreditByTaxReturnId = (taxReturnId: number) => {
+    return URL_findTaxReturnCreditByTaxReturnId.replace("{taxReturnId}", taxReturnId.toString());
+}
+
+// Create new TaxReturnCredit
+export const URL_createTaxReturnCredit = taxReturnCreditUrl;
+
+// Update TaxReturnCredit
+export const URL_updateTaxReturnCredit = taxReturnCreditUrl;
+
+// Delete TaxReturnCredit by ID
+export const URL_deleteTaxReturnCredit = `${taxReturnCreditUrl}/{id}`;
+export const getUrl_deleteTaxReturnCreditById = (id: number) => {
+    return URL_deleteTaxReturnCredit.replace("{id}", id.toString());
+}
+
+// --- W2 CONTROLLER ---
+
+const w2Url = URL + "/w2s";
+
+// Add new W2
+export const URL_addW2sByTaxReturnId = w2Url;
+
+// Find W2 by ID
+export const URL_findW2ById = `${w2Url}/{id}`;
+export const getUrl_findW2ById = (id: number) => {
+    return URL_findW2ById.replace("{id}", id.toString());
+}
+
+// Find all W2s by UserId and optionally by Year
+export const URL_findAllW2sByUserId = w2Url;
+
+// Find all W2s by Tax Return ID
+export const URL_findAllW2sByTaxReturnId = `${w2Url}/w2`;
+
+// Update an existing W2
+export const URL_updateW2 = `${w2Url}/{id}`;
+export const getUrl_updateW2 = (id: number) => {
+    return URL_updateW2.replace("{id}", id.toString());
+}
+
+// Delete W2 by ID
+export const URL_deleteW2ById = `${w2Url}/{id}`;
+export const getUrl_deleteW2ById = (id: number) => {
+    return URL_deleteW2ById.replace("{id}", id.toString());
+}
+
+// Upload image to S3
+export const URL_uploadImageToS3 = `${w2Url}/{id}/image`;
+export const getUrl_uploadImageToS3 = (id: number) => {
+    return URL_uploadImageToS3.replace("{id}", id.toString());
+}
+
+// Download image from S3
+export const URL_downloadImageFromS3 = `${w2Url}/{id}/image`;
+export const getUrl_downloadImageFromS3 = (id: number) => {
+    return URL_downloadImageFromS3.replace("{id}", id.toString());
+}

--- a/src/api/services/TransactionService.tsx
+++ b/src/api/services/TransactionService.tsx
@@ -1,0 +1,33 @@
+import { URL } from '../Endpoint';
+
+const transactionsUrl = URL + "/transactions";
+
+// Mapping for getting all transactions by userId
+export const URL_getTransactionsBYUserId = transactionsUrl;
+
+// Mapping for getting the most recent 5 transactions
+export const URL_getRecentFiveTransactions = `${transactionsUrl}/recentTransactions`;
+
+// Mapping for getting transaction for the current month
+export const URL_getTransactionsFromCurrentMonth = `${transactionsUrl}/currentMonthTransactions`;
+
+// Mapping for getting all transactions by vendorName and userId
+export const URL_getTransactionsByUserIdAndVendorName = `${transactionsUrl}/vendor/{vendorName}`;
+export const getUrl_getTransactionsByUserIdAndVendorName = (vendorName: string) => {
+    return URL_getTransactionsByUserIdAndVendorName.replace("{vendorName}", vendorName);
+}
+
+// Mapping for creating a transaction
+export const URL_createTransaction = transactionsUrl;
+
+// Mapping for updating a transaction
+export const URL_updateTransaction = `${transactionsUrl}/{id}`;
+export const getUrl_updateTransaction = (id: number) => {
+    return URL_updateTransaction.replace("{id}", id.toString());
+}
+
+// Mapping for deleting a transaction with transaction ID
+export const URL_deleteTransaction = `${transactionsUrl}/{id}`;
+export const getUrl_deleteTransaction = (id: number) => {
+    return URL_deleteTransaction.replace("{id}", id.toString());
+}

--- a/src/api/services/UserService.tsx
+++ b/src/api/services/UserService.tsx
@@ -1,0 +1,9 @@
+import { URL } from '../Endpoint';
+
+const usersUrl = URL + "/users";
+
+export const URL_findAllUsers = usersUrl;
+export const URL_findUserById = usersUrl + "/user";
+export const URL_createUser = usersUrl;
+export const URL_updateUser = usersUrl;
+export const URL_deleteUser = usersUrl;

--- a/src/pages/Accounts/AccountModal.tsx
+++ b/src/pages/Accounts/AccountModal.tsx
@@ -20,6 +20,8 @@ import { useTranslation } from "react-i18next";
 import React, { FormEvent, useEffect, useState } from "react";
 import { useAuthentication } from "../../contexts/AuthenticationContext";
 
+import { URL_getAccountsByUserId } from "../../api/services/AccountService";
+
 interface AccountModalProps {
     onAccountAdded: (account: Account) => void;
 }
@@ -60,7 +62,7 @@ const AccountModal: React.FC<AccountModalProps> = ({ onAccountAdded }) => {
 
         e.currentTarget.reset();
 
-        fetch("http://localhost:8125/accounts", {
+        fetch(URL_getAccountsByUserId, {
             method: "POST",
             headers: { Authorization: `Bearer ${jwt}`, "Content-Type": "application/json" },
             body: JSON.stringify(fields)

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -13,6 +13,8 @@ import SavingsOutlinedIcon from '@mui/icons-material/SavingsOutlined';
 
 import { deleteAccountAPI } from "../Tax/taxesAPI";
 
+import { URL_getAccountsByUserId } from "../../api/services/AccountService";
+
 const Accounts: React.FC = () => {
     const { t } = useTranslation();
     const { jwt } = useAuthentication();
@@ -34,7 +36,7 @@ const Accounts: React.FC = () => {
     useEffect(() => {
         if (!jwt) return; // to prevent an unnecessary 401
 
-        fetch("http://localhost:8125/accounts", { headers: { Authorization: `Bearer ${jwt}` } })
+        fetch(URL_getAccountsByUserId, { headers: { Authorization: `Bearer ${jwt}` } })
             .then((res) => {
                 if (res.ok) {
                     return res.json().then((data: Account[]) => {

--- a/src/pages/AuthenticationPages/Login.tsx
+++ b/src/pages/AuthenticationPages/Login.tsx
@@ -5,6 +5,7 @@ import { Link, Navigate } from "react-router-dom";
 import { useAuthentication } from "../../contexts/AuthenticationContext";
 import { useDispatch } from "react-redux";
 import { setAuthenticated } from "../../util/redux/authSlice";
+import { URL_loginUser, URL_oauth2SocialLogin } from "../../api/services/AuthService";
 
 const Login: React.FC = () => {
     const { t } = useTranslation();
@@ -24,7 +25,7 @@ const Login: React.FC = () => {
             password: e.currentTarget.elements.password.value
         };
 
-        const res = await fetch("http://localhost:8125/auth/login", {
+        const res = await fetch(URL_loginUser, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(fields),
@@ -108,7 +109,7 @@ const Login: React.FC = () => {
                                 outline
                                 className="width-full"
                                 onClick={() =>
-                                    window.location.replace("http://localhost:8125/auth/login/oauth2")
+                                    window.location.replace(URL_oauth2SocialLogin)
                                 }
                             >
                                 {t("auth.google")}

--- a/src/pages/AuthenticationPages/Register.tsx
+++ b/src/pages/AuthenticationPages/Register.tsx
@@ -3,6 +3,7 @@ import { FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, Navigate, useNavigate } from "react-router-dom";
 import { useAuthentication } from "../../contexts/AuthenticationContext";
+import { URL_oauth2SocialLogin, URL_registerUser } from "../../api/services/AuthService";
 
 const Register: React.FC = () => {
     const navigate = useNavigate();
@@ -29,7 +30,7 @@ const Register: React.FC = () => {
             return;
         }
 
-        const res = await fetch("http://localhost:8125/auth/register", {
+        const res = await fetch(URL_registerUser, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(fields)
@@ -113,7 +114,7 @@ const Register: React.FC = () => {
                                 outline
                                 className="width-full"
                                 onClick={() =>
-                                    window.location.replace("http://localhost:8125/auth/login/oauth2")
+                                    window.location.replace(URL_oauth2SocialLogin)
                                 }
                             >
                                 {t("auth.google")}

--- a/src/pages/Budgets/components/requests/accountRequests.ts
+++ b/src/pages/Budgets/components/requests/accountRequests.ts
@@ -1,5 +1,6 @@
 import Cookies from "js-cookie";
-const url = "http://localhost:8125";
+
+import { URL as url } from "../../../../api/Endpoint";
 
 type Account = {
     id: number;

--- a/src/pages/Budgets/components/requests/bucketRequests.ts
+++ b/src/pages/Budgets/components/requests/bucketRequests.ts
@@ -1,6 +1,6 @@
 import { SavingsBucketRowProps } from "../../../../types/budgetInterfaces";
 import Cookies from "js-cookie";
-const url = "http://localhost:8125";
+import { URL as url } from "../../../../api/Endpoint";
 
 export async function getBuckets(): Promise<SavingsBucketRowProps[]> {
     const endpoint = `${url}/buckets/user`;

--- a/src/pages/Budgets/components/requests/budgetRequests.ts
+++ b/src/pages/Budgets/components/requests/budgetRequests.ts
@@ -1,6 +1,6 @@
 import { BudgetRowProps } from "../../../../types/budgetInterfaces";
 import Cookies from "js-cookie";
-const url = "http://localhost:8125";
+import { URL as url } from "../../../../api/Endpoint";
 
 export async function getBudgetsById() {
     const endpoint = `${url}/budgets`;

--- a/src/pages/Budgets/components/requests/summaryRequests.ts
+++ b/src/pages/Budgets/components/requests/summaryRequests.ts
@@ -1,5 +1,5 @@
 import { createMonthlySummaryAPI, getMonthlySummaryAPI, updateMonthlySummaryAPI } from "../../../Tax/taxesAPI";
-const url = "http://localhost:8125";
+import { URL as url } from "../../../../api/Endpoint";
 
 export async function getMonthlySummary(monthYear: string): Promise<MonthlySummary> {
     return getMonthlySummaryAPI(monthYear).then((res) => {

--- a/src/pages/Budgets/components/util/transactionsCalculator.ts
+++ b/src/pages/Budgets/components/util/transactionsCalculator.ts
@@ -1,6 +1,6 @@
 import { BudgetRowProps } from "../../../../types/budgetInterfaces";
 import Cookies from "js-cookie";
-const url = "http://localhost:8125";
+import { URL as url } from "../../../../api/Endpoint";
 
 // TODO Given a list of transactions, return budget totals
 const endpoint = `${url}/budgets`;

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -4,6 +4,8 @@ import { Outlet } from "react-router-dom";
 import { setAuthenticated } from "../util/redux/authSlice";
 import Cookies from "js-cookie";
 
+import { URL_validateJwt } from "../api/services/AuthService";
+
 const Root: React.FC = () => {
     //Check if authenticated
     const token = Cookies.get("jwt");
@@ -11,7 +13,7 @@ const Root: React.FC = () => {
 
     //This is a very hacky solution to doing a network validation
     useEffect(() => {
-        fetch("http://localhost:8125/auth/validate", {
+        fetch(URL_validateJwt, {
             headers: { Authorization: `Bearer ${token}` }
         })
             .then((response) => {

--- a/src/pages/Tax/index.ts
+++ b/src/pages/Tax/index.ts
@@ -2,9 +2,11 @@ import axios from "axios";
 import Cookies from "js-cookie";
 //const jwtCookie = Cookies.get("jwt");
 
+import { URL } from "../../api/Endpoint";
+
 const apiClient = axios.create({
     // hiding the URL in the .env file
-    baseURL: `http://localhost:8125`,
+    baseURL: URL,
     headers: {
         "Content-Type": "application/json"
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
+import { env } from "node:process";
+
 export default defineConfig(({ command, mode }) => {
     // Load environment variables from .env file based on the current mode (e.g., development, production)
     const env = loadEnv(mode, process.cwd());
@@ -12,7 +14,7 @@ export default defineConfig(({ command, mode }) => {
                 // Proxy requests from /api to the backend URL specified in the environment variables
                 "/dunce": {
                     //target: "http://localhost:8125",
-                    target: "http://localhost:8125",
+                    target: env.BASE_API_ENDPOINT,
                     changeOrigin: true,
                     rewrite: (path) => path.replace(/^\/dunce/, "")
                 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-import { env } from "node:process";
-
 export default defineConfig(({ command, mode }) => {
     // Load environment variables from .env file based on the current mode (e.g., development, production)
-    // const env = loadEnv(mode, process.cwd());
+    const env = loadEnv(mode, process.cwd());
 
     return {
         plugins: [react()],
@@ -13,7 +11,6 @@ export default defineConfig(({ command, mode }) => {
             proxy: {
                 // Proxy requests from /api to the backend URL specified in the environment variables
                 "/dunce": {
-                    //target: "http://localhost:8125",
                     target: env.BASE_API_ENDPOINT,
                     changeOrigin: true,
                     rewrite: (path) => path.replace(/^\/dunce/, "")

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { env } from "node:process";
 
 export default defineConfig(({ command, mode }) => {
     // Load environment variables from .env file based on the current mode (e.g., development, production)
-    const env = loadEnv(mode, process.cwd());
+    // const env = loadEnv(mode, process.cwd());
 
     return {
         plugins: [react()],


### PR DESCRIPTION
Short: Went through and refactored all hard coded endpoints to point to a centralized variable that extracts from the environment.

Long:
Created an api folder inside src that holds a base Endpoint.tsx file, which contains the base URL. Inside the api folder is the services folder, which hold files for all services that contain outward-facing API endpoints, and contains each endpoint inside of those services with the naming convention "URL_<Spring method name>", and containing the comment about the method as noted in Spring. All of these URLs use the Endpoint base URL as a base.

After doing this, I rewrote all references to localhost to point to one of the URLs in the api folder.

IMPORTANT NOTE:
On top of touching a lot of files, I could have replaced one of the localhost endpoints with something wrong. This pull is **extremely dangerous** and should be approved after a review from **all** frontend testers.